### PR TITLE
using new collections name

### DIFF
--- a/docx/bookmark.py
+++ b/docx/bookmark.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import Sequence
+from collections.abc import Sequence
 from itertools import chain
 
 from docx.oxml.ns import qn


### PR DESCRIPTION
`Sequence` was moved to `collections.abc`. Was a warning since Python 3.07, but with 3.10 it is an error.